### PR TITLE
Use get_phantom_base_url instead of 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ This table lists the configuration variables required to operate Link. These var
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
-**https_port** | optional | string | Splunk SOAR HTTPS port if your instance uses one other than 443 |
 **auth_token** | optional | password | Splunk SOAR auth token if your instance requires auth for internal 127.0.0.1 calls |
 **debug** | optional | boolean | Print debugging statements to log |
 

--- a/link.json
+++ b/link.json
@@ -22,27 +22,20 @@
         }
     ],
     "configuration": {
-        "https_port": {
-            "description": "Splunk SOAR HTTPS port if your instance uses one other than 443",
-            "data_type": "string",
-            "order": 0,
-            "name": "https_port",
-            "id": 0
-        },
         "auth_token": {
             "description": "Splunk SOAR auth token if your instance requires auth for internal 127.0.0.1 calls",
             "data_type": "password",
-            "order": 1,
+            "order": 0,
             "name": "auth_token",
-            "id": 1
+            "id": 0
         },
         "debug": {
             "description": "Print debugging statements to log",
             "data_type": "boolean",
             "default": false,
-            "order": 2,
+            "order": 1,
             "name": "debug",
-            "id": 2
+            "id": 1
         }
     },
     "actions": [

--- a/link.json
+++ b/link.json
@@ -184,11 +184,5 @@
             ],
             "versions": "EQ(*)"
         }
-    ],
-    "directory": "link_c5a92c45-8c3e-417b-be46-01e8d7c677a6",
-    "version": 1,
-    "appname": "-",
-    "executable": "spawn3",
-    "disabled": false,
-    "custom_made": true
+    ]
 }

--- a/link_connector.py
+++ b/link_connector.py
@@ -13,8 +13,10 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 import json
+import urllib.parse
 
 import phantom.app as phantom
+import phantom.rules as phrules
 from phantom.action_result import ActionResult
 
 
@@ -156,13 +158,9 @@ class LinkConnector(phantom.BaseConnector):
 
     def _get_base_url(self):
         self.__print("_get_base_url()", is_debug=True)
-        port = 443
-        try:
-            port = self.get_config()["https_port"]
-        except Exception as e:
-            self.debug_print(f"Exception occured while get https_port key. Exception: {e}")
-            pass
-        return f"https://127.0.0.1:{port}"
+        rest_url = phrules.build_phantom_rest_url()
+        scheme, netloc, _, _, _ = urllib.parse.urlsplit(rest_url)
+        return urllib.parse.urlunsplit((scheme, netloc, '', '', ''))
 
     def _handle_test_connectivity(self, param):
         self.__print("_handle_test_connectivity", is_debug=True)

--- a/link_connector.py
+++ b/link_connector.py
@@ -160,7 +160,7 @@ class LinkConnector(phantom.BaseConnector):
         self.__print("_get_base_url()", is_debug=True)
         rest_url = phrules.build_phantom_rest_url()
         scheme, netloc, _, _, _ = urllib.parse.urlsplit(rest_url)
-        return urllib.parse.urlunsplit((scheme, netloc, '', '', ''))
+        return urllib.parse.urlunsplit((scheme, netloc, "", "", ""))
 
     def _handle_test_connectivity(self, param):
         self.__print("_handle_test_connectivity", is_debug=True)

--- a/link_connector.py
+++ b/link_connector.py
@@ -13,10 +13,8 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 import json
-import urllib.parse
 
 import phantom.app as phantom
-import phantom.rules as phrules
 from phantom.action_result import ActionResult
 
 
@@ -158,9 +156,7 @@ class LinkConnector(phantom.BaseConnector):
 
     def _get_base_url(self):
         self.__print("_get_base_url()", is_debug=True)
-        rest_url = phrules.build_phantom_rest_url()
-        scheme, netloc, _, _, _ = urllib.parse.urlsplit(rest_url)
-        return urllib.parse.urlunsplit((scheme, netloc, "", "", ""))
+        return self.get_phantom_base_url()
 
     def _handle_test_connectivity(self, param):
         self.__print("_handle_test_connectivity", is_debug=True)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
-* Use build_phantom_rest_url instead of 127.0.0.1
+* Use get_phantom_base_url instead of 127.0.0.1

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,3 @@
 **Unreleased**
 
-* chore(ci): update pre-commit config
 * Use get_phantom_base_url instead of 127.0.0.1

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Use build_phantom_rest_url instead of 127.0.0.1


### PR DESCRIPTION
### Bug Fixes
- Fixes SOARHELP-4540 by removing the hard-coded 127.0.0.1

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that manual documentation has been updated where appropriate

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
